### PR TITLE
[merge] [feat]alert창 공통 컴포넌트

### DIFF
--- a/src/components/common/SweetAlert.js
+++ b/src/components/common/SweetAlert.js
@@ -1,0 +1,77 @@
+import { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import Swal from "sweetalert2";
+
+/* 에러 alert */
+export const useErrorAlert = () => {
+  const navigate = useNavigate();
+
+  const showErrorAlert = useCallback(
+    ({ title, text, navi }) => {
+      Swal.fire({
+        title: title,
+        text: text,
+        icon: "error",
+      }).then((result) => {
+        if (result.isConfirmed) {
+          if (navi) {
+            navigate(navi);
+          }
+        }
+      });
+    },
+    [navigate]
+  );
+  return showErrorAlert;
+};
+
+/* 확인 alert */
+export const useConfirmAlert = () => {
+  const navigate = useNavigate();
+
+  const showConfirmAlert = useCallback(
+    ({ title, text, navi }) => {
+      Swal.fire({
+        icon: "success",
+        title: title,
+        text: text,
+      }).then((result) => {
+        if (result.isConfirmed) {
+          if (navi) {
+            navigate(navi);
+          }
+        }
+      });
+    },
+    [navigate]
+  );
+  return showConfirmAlert;
+};
+
+/* 한번 더 물어보는 alert */
+export const useQuestionAlert = () => {
+  const navigate = useNavigate();
+
+  const showQuestionAlert = useCallback(
+    ({ title, text, saveText, navi }) => {
+      Swal.fire({
+        icon: "question",
+        title: title,
+        text: text,
+        showCancelButton: true,
+        confirmButtonText: "확인",
+        cancelButtonText: "취소",
+      }).then((result) => {
+        if (result.isConfirmed) {
+          Swal.fire(saveText, "", "success");
+          if (navi !== "") {
+            navigate(navi);
+          }
+        }
+      });
+    },
+    [navigate]
+  );
+
+  return showQuestionAlert;
+};

--- a/src/pages/admin/directAskPage/Enroll/Index.js
+++ b/src/pages/admin/directAskPage/Enroll/Index.js
@@ -11,11 +11,21 @@ import {
   customDate,
   customStatusName,
 } from "../../../../assets/CustomName";
+import {
+  useConfirmAlert,
+  useErrorAlert,
+  useQuestionAlert,
+} from "@components/SweetAlert";
 
 /* 답변 등록 & 문의 조회 */
 const EnrollPage = () => {
   let params = useParams().askId;
   const [askData, setAskData] = useState();
+
+  /* alert창 */
+  const showErrorAlert = useErrorAlert();
+  const showQuestionAlert = useQuestionAlert();
+  const showConfirmAlert = useConfirmAlert();
 
   useEffect(() => {
     GET_QnA(params)
@@ -37,11 +47,17 @@ const EnrollPage = () => {
   const handleSubmit = () => {
     PUT_Answer(params, answer)
       .then((data) => {
-        alert("답변이 성공적으로 등록되었습니다.");
+        showConfirmAlert({
+          title: "답변이 성공적으로 등록되었습니다.",
+        });
         // window.location.reload();
       })
       .catch((error) => {
         alert("답변 등록에 실패하였습니다. 다시 시도해 주세요.");
+        showErrorAlert({
+          title: "답변 등록에 실패하였습니다.",
+          text: "다시 시도해 주세요.",
+        });
       });
   };
 

--- a/src/pages/user/Login/AdminIndex.js
+++ b/src/pages/user/Login/AdminIndex.js
@@ -28,6 +28,11 @@ const AdminLoginPage = () => {
     POST_Login(userData)
       .then((data) => {
         if (data.data.token.role === "ADMIN") {
+          // userId, email, role은 로컬스토리지에 저장
+          localStorage.setItem("userId", data.data.userIdx);
+          localStorage.setItem("email", userData.email);
+          localStorage.setItem("role", "ADMIN");
+
           alert("관리자로 로그인되었습니다. 메인페이지로 이동합니다.");
           navigate("/admin/user");
 
@@ -40,10 +45,6 @@ const AdminLoginPage = () => {
             expires: 7,
             path: "/",
           });
-          // userId, email, role은 로컬스토리지에 저장
-          localStorage.setItem("userId", data.data.userIdx);
-          localStorage.setItem("email", userData.email);
-          localStorage.setItem("role", data.data.token.role);
         } else {
           alert("관리자 권한이 없습니다.");
         }


### PR DESCRIPTION
[alert창 종류]
: 에러 alert / 확인 alert / 한번 더 물어보는 alert

[alert창 인수 종류]
- 에러 alert / 확인 alert 인수 : title, text, navi
- 한번 더 물어보는 alert : title, text, saveText, navi

[alert창 인수 의미]
- title : 메인 텍스트
- text: 메인 텍스트 아래 작은 텍스트
- saveText: '한번 더 물어보는 alert창'에서 확인 버튼 클릭 시, 확인 alert창이 나오는데 그때 메인 텍스트에 해당.
- navi: 확인 버튼 클릭 시 이동할 url

[alert창 공통 컴포넌트 사용법]
1. 먼저 사용할 alert 함수를 적용할 컴포넌트에 선언해주세요.
```
// 예시
const showErrorAlert = useErrorAlert();
const showConfirmAlert = useConfirmAlert();
const showQuestionAlert = useQuestionAlert();
```
2. 사용할 alert 함수에 인수를 넣어주세요.
- ! 이때 사용하지 않을 인수는 값을 전해주지 않아도 돼요! 그냥 인수로 안넘겨주시면 됩니다. !
```
// 예시
showErrorAlert({
  title: "답변 등록에 실패하였습니다.",
  text: "다시 시도해 주세요.",
});
showConfirmAlert({
  title: "답변이 성공적으로 등록되었습니다.",
});
showQuestionAlert({
  title: "답변을 수정하시겠습니까?",
  text: "확인 클릭 시 수정 완료됩니다.",
  saveText: "수정 완료되었습니다.",
});
```

[alert창 디자인 깨짐 오류 대처 방법]
: 재설치해보기. 그래도 계속 깨진다면 특정 버전의 라이브러리로 설치하는 것을 추천
```
npm uninstall sweetalert2
npm install sweetalert2
```